### PR TITLE
ステータスバーを非表示にする。

### DIFF
--- a/app/src/main/java/com/example/manualfocusmacrocamera/MainActivity.kt
+++ b/app/src/main/java/com/example/manualfocusmacrocamera/MainActivity.kt
@@ -6,27 +6,38 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.annotation.RequiresApi
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.example.manualfocusmacrocamera.ui.camera.CameraScreen
 import com.example.manualfocusmacrocamera.ui.theme.MyApplicationTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    @RequiresApi(Build.VERSION_CODES.Q)
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+
+        val windowInsetsController =
+            WindowCompat.getInsetsController(window, window.decorView)
+        windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+        windowInsetsController.systemBarsBehavior =
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE // ⑤
+
         setContent {
             MyApplicationTheme {
                 Scaffold(
-                    modifier = Modifier.fillMaxSize(),
+                    contentWindowInsets = WindowInsets(0.dp)
                 ) { innerPadding ->
                     CameraScreen(
                         modifier = Modifier.padding(innerPadding)


### PR DESCRIPTION
- https://github.com/dorulovesreptominsuper/Android-manual-focus-macro-camera/issues/11
の対応。
低いOSバージョンでも動作するようにした。